### PR TITLE
Mismatch types for UserInfo struct.

### DIFF
--- a/fivesim/fivesim.go
+++ b/fivesim/fivesim.go
@@ -171,7 +171,7 @@ func (c *Client) GetUserInfo() (*UserInfo, error) {
 }
 
 // GetBalance returns user's balance
-func (c *Client) GetBalance() (float64, error) {
+func (c *Client) GetBalance() (float32, error) {
 	info, err := c.GetUserInfo()
 	if err != nil {
 		return 0.0, err
@@ -201,7 +201,7 @@ func (c *Client) GetID() (int, error) {
 }
 
 // GetRating returns user's rating
-func (c *Client) GetRating() (float64, error) {
+func (c *Client) GetRating() (float32, error) {
 	info, err := c.GetUserInfo()
 	if err != nil {
 		return 0, err

--- a/fivesim/fivesim.go
+++ b/fivesim/fivesim.go
@@ -171,7 +171,7 @@ func (c *Client) GetUserInfo() (*UserInfo, error) {
 }
 
 // GetBalance returns user's balance
-func (c *Client) GetBalance() (float32, error) {
+func (c *Client) GetBalance() (float64, error) {
 	info, err := c.GetUserInfo()
 	if err != nil {
 		return 0.0, err
@@ -201,7 +201,7 @@ func (c *Client) GetID() (int, error) {
 }
 
 // GetRating returns user's rating
-func (c *Client) GetRating() (int, error) {
+func (c *Client) GetRating() (float64, error) {
 	info, err := c.GetUserInfo()
 	if err != nil {
 		return 0, err

--- a/fivesim/responses.go
+++ b/fivesim/responses.go
@@ -16,8 +16,8 @@ type Products map[string]Product
 type UserInfo struct {
 	ID      int     `json:"id"`
 	Email   string  `json:"email"`
-	Balance float32 `json:"balance"`
-	Rating  int     `json:"rating"`
+	Balance float64 `json:"balance"`
+	Rating  float64  `json:"rating"`
 }
 
 // SMS represents info about an incoming SMS

--- a/fivesim/responses.go
+++ b/fivesim/responses.go
@@ -16,8 +16,8 @@ type Products map[string]Product
 type UserInfo struct {
 	ID      int     `json:"id"`
 	Email   string  `json:"email"`
-	Balance float64 `json:"balance"`
-	Rating  float64  `json:"rating"`
+	Balance float32 `json:"balance"`
+	Rating  float32  `json:"rating"`
 }
 
 // SMS represents info about an incoming SMS


### PR DESCRIPTION
In regards to requesting UserInfo with an API key, this error is given:

**2021/12/12 18:05:33 json: cannot unmarshal number 95.79 into Go struct field UserInfo.rating of type int
exit status**

To correct this error, the UserInfo struct and UserInfo rating function just needs to be swapped from int to float.